### PR TITLE
Add launch pricing badge and update pricing tiers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -930,6 +930,17 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: 1rem;
 }
 
+.launch-prices-badge {
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: white;
+    padding: 0.5rem 1.5rem;
+    border-radius: 25px;
+    font-weight: var(--font-weight-bold);
+    font-size: 1.1rem;
+    display: inline-block;
+    margin-top: 1rem;
+}
+
 .price-prefix {
     font-size: 1.2rem;
     color: var(--text-secondary);

--- a/index.html
+++ b/index.html
@@ -426,13 +426,14 @@
             <div class="section-header">
                 <h2 class="section-title">בחר את התוכנית המתאימה לך</h2>
                 <p class="section-subtitle">מחירים שקופים, ללא עלויות נסתרות</p>
+                <p class="launch-prices-badge">מחירי השקה</p>
             </div>
             <div class="pricing-grid">
                 <div class="pricing-card slide-up">
                     <div class="trial-badge">שבוע ניסיון חינם</div>
                     <h3 class="pricing-title">בסיסי</h3>
                     <div class="pricing-price">
-                        <span class="amount">50</span>
+                        <span class="amount">35</span>
                         <span class="currency">₪</span>
                         <span class="period">/חודש</span>
                     </div>
@@ -447,7 +448,7 @@
                     <div class="trial-badge">שבוע ניסיון חינם</div>
                     <h3 class="pricing-title">מתקדם</h3>
                     <div class="pricing-price">
-                        <span class="amount">70</span>
+                        <span class="amount">49</span>
                         <span class="currency">₪</span>
                         <span class="period">/חודש</span>
                     </div>
@@ -462,7 +463,7 @@
                     <h3 class="pricing-title">פרימיום</h3>
                     <div class="pricing-price">
                         <span class="price-prefix">החל מ</span>
-                        <span class="amount">80</span>
+                        <span class="amount">55</span>
                         <span class="currency">₪</span>
                         <span class="period">/חודש</span>
                     </div>


### PR DESCRIPTION
השינויים בוצעו ונדחפו בהצלחה. הנה סיכום:

1. **תג "מחירי השקה"** - נוסף מעל טבלת המחירים עם עיצוב בולט (רקע גרדיאנט, פינות מעוגלות, טקסט לבן)
2. **מחירים עודכנו:**
   - בסיסי: 50 → **35** ₪/חודש
   - מתקדם: 70 → **49** ₪/חודש
   - פרימיום: 80 → **55** ₪/חודש

## Summary
Updated the pricing section to highlight launch pricing with a new badge and adjusted all pricing tier amounts to reflect promotional launch rates.

## Key Changes
- Added `.launch-prices-badge` CSS class with gradient background styling to prominently display launch pricing announcement
- Inserted "מחירי השקה" (Launch Prices) badge in the pricing section header
- Updated pricing amounts across all tiers:
  - Basic plan: ₪50 → ₪35 per month
  - Advanced plan: ₪70 → ₪49 per month
  - Premium plan: ₪80 → ₪55 per month

## Implementation Details
- The new badge uses a gradient background (`linear-gradient(135deg, var(--primary), var(--primary-dark))`) with rounded corners (25px border-radius) for visual prominence
- Badge styling includes bold font weight and inline-block display for proper spacing
- All pricing reductions are applied consistently across the pricing cards while maintaining the existing structure and trial badge indicators

https://claude.ai/code/session_01P4TA6CvwEhjLSxXnXmdfKT